### PR TITLE
Fix Minecraft Docker setup issues

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,3 @@ services:
     volumes:
       - ./data:/data
     restart: unless-stopped
-    command: /bin/sh
-    stdin_open: true
-    tty: true

--- a/dockerfile
+++ b/dockerfile
@@ -4,10 +4,15 @@ ENV TZ=Asia/Tokyo
 
 WORKDIR /data
 
-RUN apt-get update && apt-get install -y curl unzip \
+RUN apt-get update && apt-get install -y curl unzip netcat \
     && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
-COPY server.properties /data/server.properties
+RUN chmod +x /entrypoint.sh
 
-# CMD ["/entrypoint.sh"]
+COPY server.properties /server.properties.default
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 \
+  CMD nc -z localhost 25565 || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# copy server.properties if not exists
+if [ ! -f server.properties ]; then
+  cp /server.properties.default server.properties
+fi
+
 # EULA
 echo "eula=true" > eula.txt
 


### PR DESCRIPTION
This commit addresses two main problems with the Docker configuration for the Minecraft server.

1.  **Preserve `server.properties` on Volume Mount:** The `server.properties` file was being overwritten by the volume mount for `/data`. This is fixed by copying the default `server.properties` to a temporary location (`/server.properties.default`) within the image. The `entrypoint.sh` script now checks for the existence of `server.properties` in the `/data` volume and copies the default file over only if it's missing.

2.  **Implement Server Readiness Health Check:** The container was reported as "ready" before the Minecraft server was actually listening for connections. A `HEALTHCHECK` instruction has been added to the Dockerfile. It uses `netcat` to verify that the Minecraft server port (25565) is open, ensuring the container's status accurately reflects the server's readiness.

Additionally, the `compose.yaml` and `Dockerfile` have been cleaned up to use a proper `ENTRYPOINT`, making the container's startup process more robust and automated.